### PR TITLE
Separate builder from client

### DIFF
--- a/Source/SoapHttpClient/Extensions/HttpClientExtensions.cs
+++ b/Source/SoapHttpClient/Extensions/HttpClientExtensions.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using SoapHttpClient.Enums;
+
+namespace SoapHttpClient
+{
+    public static class HttpClientExtensions
+    {
+        public static Task<HttpResponseMessage> PostSoapAsync(this HttpClient client,
+            Uri endpoint,
+            SoapVersion soapVersion,
+            IEnumerable<XElement> bodies,
+            IEnumerable<XElement> headers = null,
+            string action = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (endpoint == null)
+                throw new ArgumentNullException(nameof(endpoint));
+
+            if (bodies == null)
+                throw new ArgumentNullException(nameof(bodies));
+
+            var builder = new SoapMessageBuilder
+            {
+                EndpointUri = endpoint,
+                SoapAction = action,
+                SoapVersion = soapVersion
+            };
+
+            foreach (var element in bodies)
+                builder.Bodies.Add(element);
+
+            foreach (var element in headers ?? new XElement[0])
+                builder.Headers.Add(element);
+
+            var message = builder.Build();
+
+            return client.SendAsync(message, cancellationToken);
+        }
+    }
+}

--- a/Source/SoapHttpClient/SoapClient.cs
+++ b/Source/SoapHttpClient/SoapClient.cs
@@ -45,62 +45,12 @@ namespace SoapHttpClient
             string action = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (endpoint == null)
-                throw new ArgumentNullException(nameof(endpoint));
-
-            if (bodies == null)
-                throw new ArgumentNullException(nameof(bodies));
-
-            if (!bodies.Any())
-                throw new ArgumentException("Bodies element cannot be empty", nameof(bodies));
-
-            // Get configuration based on version
-            var messageConfiguration = new SoapMessageConfiguration(soapVersion);
-
-            // Get the envelope
-            var envelope = GetEnvelope(messageConfiguration);
-
-            // Add headers
-            if (headers != null && headers.Any())
-                envelope.Add(new XElement(messageConfiguration.Schema + "Header", headers));
-
-            // Add bodies
-            envelope.Add(new XElement(messageConfiguration.Schema + "Body", bodies));
-
-            // Get HTTP content
-            var content = new StringContent(envelope.ToString(), Encoding.UTF8, messageConfiguration.MediaType);
-
-            // Add SOAP action if any
-            if (action != null)
-            {
-                content.Headers.Add("SOAPAction", action);
-
-                if (messageConfiguration.SoapVersion == SoapVersion.Soap12)
-                    content.Headers.ContentType.Parameters.Add(
-                        new NameValueHeaderValue("ActionParameter", $"\"{action}\""));
-            }
-            
-            // Execute call
-            return _httpClient.PostAsync(endpoint, content, cancellationToken);
-        }
-
-        #region Private Methods
-
-        private static XElement GetEnvelope(SoapMessageConfiguration soapMessageConfiguration)
-        {
-            return new 
-                XElement(
-                    soapMessageConfiguration.Schema + "Envelope",
-                    new XAttribute(
-                        XNamespace.Xmlns + "soapenv",
-                        soapMessageConfiguration.Schema.NamespaceName));
+            return _httpClient.PostSoapAsync(endpoint, soapVersion, bodies, headers, action, cancellationToken);
         }
 
         private static HttpClient DefaultHttpFactory()
             => new HttpClient(new HttpClientHandler {
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
             }, disposeHandler: false);
-
-        #endregion Private Methods
     }
 }

--- a/Source/SoapHttpClient/SoapMessageBuilder.cs
+++ b/Source/SoapHttpClient/SoapMessageBuilder.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Xml.Linq;
+using SoapHttpClient.DTO;
+using SoapHttpClient.Enums;
+
+namespace SoapHttpClient
+{
+    public class SoapMessageBuilder
+    {
+        private readonly IList<XElement> _bodies = new List<XElement>();
+        private readonly IList<XElement> _headers = new List<XElement>();
+
+        public ICollection<XElement> Bodies => _bodies;
+        public ICollection<XElement> Headers => _headers;
+        public string SoapAction { get; set; }
+        public Uri EndpointUri { get; set; }
+        public SoapVersion SoapVersion { get; set; }
+        
+        public HttpRequestMessage Build()
+        {
+            if (EndpointUri == null)
+                throw new InvalidOperationException($"{nameof(EndpointUri)} property not set");
+
+            if (!Bodies.Any())
+                throw new InvalidOperationException("Bodies property cannot be empty");
+
+            // Get configuration based on version
+            var messageConfiguration = new SoapMessageConfiguration(SoapVersion);
+
+            // Get the envelope
+            var envelope = GetEnvelope(messageConfiguration);
+
+            // Add headers
+            if (Headers.Any())
+                envelope.Add(new XElement(messageConfiguration.Schema + "Header", Headers));
+
+            // Add bodies
+            envelope.Add(new XElement(messageConfiguration.Schema + "Body", Bodies));
+
+            // Get HTTP content
+            var content = new StringContent(envelope.ToString(), Encoding.UTF8, messageConfiguration.MediaType);
+
+            // Add SOAP action if any
+            if (SoapAction != null)
+            {
+                content.Headers.Add("SOAPAction", SoapAction);
+
+                if (messageConfiguration.SoapVersion == SoapVersion.Soap12)
+                    content.Headers.ContentType.Parameters.Add(
+                        new NameValueHeaderValue("ActionParameter", $"\"{SoapAction}\""));
+            }
+            
+            return new HttpRequestMessage(HttpMethod.Post, EndpointUri)
+            {
+                Content = content
+            };
+        }
+
+        private static XElement GetEnvelope(SoapMessageConfiguration soapMessageConfiguration)
+        {
+            return new 
+                XElement(
+                    soapMessageConfiguration.Schema + "Envelope",
+                    new XAttribute(
+                        XNamespace.Xmlns + "soapenv",
+                        soapMessageConfiguration.Schema.NamespaceName));
+        }
+    }
+}


### PR DESCRIPTION
In my project i make use of aspnet's `IHttpClientFactory` and thus prefer not to wrap my `HttpClient` in a `SoapClient` instance. I do need the _magic_ that constructs the soap request, you have created.

To remedy this, i have:
- Introduced a `SoapMessageBuilder` which is solely responsible for building an `HttpRequestMessage` based on it's properties;
- Introduced an extension method that directly extends the `HttpClient`, so that i can inject my `HttpClient` and call `PostSoapAsync()` on it directly;
- Refactored the `SoapClient` to call the new extension method;

There are no breaking changes, so the `SoapClient` can be used as it alwasy has been used. It does allow for a _closer-to-the-metal_ approach, where the caling code has access to and full control over the `HttpRequestMessage`.

As an aside, after my changes all tests pass except one, but that test also fails when i run the tests in the (your) master branch.

```bash
dotnet test
Build started, please wait...
Build completed.

Test run for /Users/wis3guy/Projects/SoapHttpClient/Tests/SoapHttpClient.Tests/bin/Debug/netcoreapp2.0/SoapHttpClient.Tests.dll(.NETCoreApp,Version=v2.0)
Microsoft (R) Test Execution Command Line Tool Version 15.9.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: <null>, Headers:
{
}
StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: <null>, Headers:
{
}
StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: <null>, Headers:
{
}
StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: <null>, Headers:
{
}
StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: <null>, Headers:
{
}
[xUnit.net 00:00:01.17]     Cancel NASA's heliocentric trajectories (Soap 1.1) Operation Cancelled [FAIL]
Failed   Cancel NASA's heliocentric trajectories (Soap 1.1) Operation Cancelled
Error Message:
 Assert.Throws() Failure
Expected: typeof(System.OperationCanceledException)
Actual:   typeof(System.Threading.Tasks.TaskCanceledException): A task was canceled.
---- System.Threading.Tasks.TaskCanceledException : A task was canceled.
Stack Trace:
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at System.Net.Http.HttpClient.<FinishSendAsyncBuffered>d__58.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at SoapHttpClient.Tests.SoapClientExamples.<>c__DisplayClass1_0.<<Nasa_Cancel_Trajectory_Soap11_OperationCancelled>b__0>d.MoveNext() in /Users/wis3guy/Projects/SoapHttpClient/Tests/SoapHttpClient.Tests/SoapClientExamples.cs:line 46
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
----- Inner Stack Trace -----
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at System.Net.Http.HttpClient.<FinishSendAsyncBuffered>d__58.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at SoapHttpClient.Tests.SoapClientExamples.<>c__DisplayClass1_0.<<Nasa_Cancel_Trajectory_Soap11_OperationCancelled>b__0>d.MoveNext() in /Users/wis3guy/Projects/SoapHttpClient/Tests/SoapHttpClient.Tests/SoapClientExamples.cs:line 46
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)

Total tests: 14. Passed: 13. Failed: 1. Skipped: 0.
Test Run Failed.
Test execution time: 1.8434 Seconds
```